### PR TITLE
Add option to customize robot name when posting with web API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ Hubot adapter through Slack Api and Xmpp gateway
 
 need HUBOT_SLACK_API_TOKEN environement variable
 
-you can also add HUBOT_SLACK_ICON_URL to set a custom icon url
+
+you can also add HUBOT_SLACK_ICON_URL to set a custom icon url and HUBOT_SLACK_ROBOT_NICKNAME to post on slack with a custom name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-slack-xmpp-api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Hubot adapter through Slack Api and Xmpp gateway",
   "author": "Mathieu Morlon",
   "license": "ISC",

--- a/src/xmpp-api.coffee
+++ b/src/xmpp-api.coffee
@@ -1,32 +1,32 @@
-xmpp = require 'hubot-xmpp'
+xmpp  = require 'hubot-xmpp'
 slack = require 'hubot-slack'
 https = require 'https'
 
 exports.use = (robot) ->
-  
+
   adapter = xmpp.use robot
   Slack = slack.use robot
-  
+
   adapter.send = (envelope, strings...) ->
     [channel] = envelope.room.split '@'
 
     strings.forEach (str) =>
       str = @escapeHtml str
       args =
-        username   : @robot.name
+        username   : process.env.HUBOT_SLACK_ROBOT_NICKNAME or @robot.name
         channel    : "\##{channel}"
         text       : str
         token      : process.env.HUBOT_SLACK_API_TOKEN
         icon_url   : process.env.HUBOT_SLACK_ICON_URL or "http://lorempixel.com/48/48/cats/"
 
       https.get "https://slack.com/api/chat.postMessage?#{@serialize args}"
-  
+
   adapter.escapeHtml = (string) ->
     Slack.escapeHtml string
 
   adapter.unescapeHtml = (string) ->
     Slack.unescapeHtml string
-  
+
   adapter.serialize = (obj, prefix) ->
     str = []
     for p, v of obj


### PR DESCRIPTION
To fit new XMPP Slack restriction we need to give the robot our username so i added an option to customize the nickname we want to post with :smile: 
